### PR TITLE
feat: add mail config in .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CodeIgniter Multiple SMTP Configuration
+
 A lightweight Multi-SMTP configuration helper for your CodeIgniter 4 application. This package allows you to use different email accounts simultaneously.
 
 ![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.8-blue)
@@ -17,6 +18,34 @@ php spark smtpconfig:publish
 ```
 
 After that, check the `app/Config/MultiEmail.php` file, and set it up with your email credentials.
+
+## Configuring SMTP in the `.env` File
+
+We recommend setting the configuration for each SMTP email in the `.env` file instead of using `app/Config/MultiEmail`.
+
+For example, you can proceed as follows:
+
+```
+#--------------------------------------------------------------------
+# MULTI-SMTP CONFIGURATION SETTINGS
+#--------------------------------------------------------------------
+
+# email.default.fromName =
+# email.default.fromEmail =
+# email.default.protocol = smtp
+# email.default.SMTPUser =
+# email.default.SMTPPass =
+# email.default.SMTPHost = smtp.gmail.com
+# email.default.SMTPPort = 587
+
+# email.outlook.fromName =
+# email.outlook.fromEmail =
+# email.outlook.protocol = smtp
+# email.outlook.SMTPUser =
+# email.outlook.SMTPPass =
+# email.outlook.SMTPHost = smtp.office365.com
+# email.outlook.SMTPPort = 587
+```
 
 ## Usage
 

--- a/src/Helpers/multi_email_helper.php
+++ b/src/Helpers/multi_email_helper.php
@@ -27,18 +27,18 @@ if (! function_exists('multi_email')) {
             throw new Exception("Cannot send email from 'multi_email' helper.\n Undefined group name:  $group");
         }
 
-        $defaultGroup  = !empty($group) ? $group : setting('MultiEmail.defaultGroup');
+        $defaultGroup  = !empty($group) ? strtolower($group) : setting('MultiEmail.defaultGroup');
 
         $config = [
-            'fromEmail'     => setting('MultiEmail.' . $defaultGroup)['fromEmail'],
-            'fromName'      => setting('MultiEmail.' . $defaultGroup)['fromName'],
+            'fromEmail'     => env("email.$defaultGroup.fromEmail", setting('MultiEmail.' . $defaultGroup)['fromEmail']),
+            'fromName'      => env("email.$defaultGroup.fromName", setting('MultiEmail.' . $defaultGroup)['fromName']),
             'userAgent'     => setting('MultiEmail.' . $defaultGroup)['userAgent'],
-            'protocol'      => setting('MultiEmail.' . $defaultGroup)['protocol'],
+            'protocol'      => env("email.$defaultGroup.protocol", setting('MultiEmail.' . $defaultGroup)['protocol']),
             'mailPath'      => setting('MultiEmail.' . $defaultGroup)['mailPath'],
-            'SMTPHost'      => setting('MultiEmail.' . $defaultGroup)['SMTPHost'],
-            'SMTPUser'      => setting('MultiEmail.' . $defaultGroup)['SMTPUser'],
-            'SMTPPass'      => setting('MultiEmail.' . $defaultGroup)['SMTPPass'],
-            'SMTPPort'      => setting('MultiEmail.' . $defaultGroup)['SMTPPort'],
+            'SMTPHost'      => env("email.$defaultGroup.SMTPHost", setting('MultiEmail.' . $defaultGroup)['SMTPHost']),
+            'SMTPUser'      => env("email.$defaultGroup.SMTPUser", setting('MultiEmail.' . $defaultGroup)['SMTPUser']),
+            'SMTPPass'      => env("email.$defaultGroup.SMTPPass", setting('MultiEmail.' . $defaultGroup)['SMTPPass']),
+            'SMTPPort'      => (int) env("email.$defaultGroup.SMTPPort", setting('MultiEmail.' . $defaultGroup)['SMTPPort']),
             'SMTPTimeout'   => setting('MultiEmail.' . $defaultGroup)['SMTPTimeout'],
             'SMTPKeepAlive' => setting('MultiEmail.' . $defaultGroup)['SMTPKeepAlive'],
             'SMTPCrypto'    => setting('MultiEmail.' . $defaultGroup)['SMTPCrypto'],


### PR DESCRIPTION
This PR allows you to set the mail config in .env file

Example:

```env
email.default.fromName = "Sender Name"
email.default.fromEmail = budi@gmail.com
email.default.protocol = smtp
email.default.SMTPUser = budi@gmail.com
email.default.SMTPPass = "qwer asdf cxsd aaes"
email.default.SMTPHost = smtp.gmail.com
email.default.SMTPPort = 587

# email.outlook.fromName =
# email.outlook.fromEmail =
# email.outlook.protocol = smtp
# email.outlook.SMTPUser =
# email.outlook.SMTPPass =
# email.outlook.SMTPHost = smtp.office365.com
# email.outlook.SMTPPort = 587
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added guidance for configuring SMTP settings directly within the `.env` file for improved email setup.
	- Included examples for setting up multiple SMTP configurations for Gmail and Outlook.

- **Bug Fixes**
	- Enhanced email configuration retrieval to prioritize environment-specific settings, improving flexibility and robustness. 

- **Documentation**
	- Updated the README to clarify the recommended practices for SMTP configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->